### PR TITLE
Fix context path warning

### DIFF
--- a/src/main/java/org/tango/web/server/tomcat/WebappConfiguration.java
+++ b/src/main/java/org/tango/web/server/tomcat/WebappConfiguration.java
@@ -41,7 +41,7 @@ public class WebappConfiguration implements TomcatConfiguration {
 
     public void configure(Tomcat tomcat){
         logger.debug("Add webapp[tango] tomcat for device");
-        org.apache.catalina.Context context = tomcat.addWebapp("tango", webappPath);
+        org.apache.catalina.Context context = tomcat.addWebapp("/tango", webappPath);
 
         WebappLoader loader =
                 new WebappLoader(Thread.currentThread().getContextClassLoader());


### PR DESCRIPTION
Fix following warning:
org.apache.catalina.core.StandardContext setPath
WARNING: A context path must either be an empty string or start with a '/' and do not end with a '/'. The path [tango] does not meet these criteria and has been changed to [/tango]